### PR TITLE
chore: Exclude some obsolete services from check-names

### DIFF
--- a/.toys/check-names.rb
+++ b/.toys/check-names.rb
@@ -16,6 +16,28 @@
 
 desc "Verify that event namespaces are consistent with client libraries"
 
+long_desc \
+  "Audit a set of changes to event definitions, and check each one against " \
+    "the GAPIC code in google-cloud-ruby. Normally, we expect each event to " \
+    "have an associated service expressed in one of our client libraries. " \
+    "If any discrepancies are discovered, fail and print the results.",
+  "",
+  "We do this because we want consistency between the Ruby namespaces in the " \
+    "client libraries and the Ruby namespaces in the cloud events. Sometimes " \
+    "this requires some manual adjustments to the proto options in the event " \
+    "protos. For example, the google.events.cloud.pubsub.v1 events should be " \
+    "in Ruby namespace Google::Events::Cloud::PubSub::V1 (note the " \
+    "capitalization of PubSub) to match the namespace capitalization in the " \
+    "PubSub client library, and this requires a proto option. If this check " \
+    "flags a discrepancy, it is important to determine why the Ruby name " \
+    "being generated for the event does not match what we're doing for the " \
+    "client library, and we might need to update some options accordingly.",
+  "",
+  "It is also possible for this check to flag false positives, in cases " \
+    "where there is a known legitimate naming difference. Any such false " \
+    "positives should be added to the EXCLUDE_MODULES list in this check's " \
+    "source code."
+
 flag :all_files, "--all" do |f|
   f.desc "Check all event files instead of looking for changes"
 end
@@ -40,10 +62,19 @@ include :git_cache
 include :exec
 include :terminal
 
+# Modules to exclude from the check for various reasons.
 EXCLUDE_MODULES = [
+  # Audit events have no associated client
   /^::Google::Cloud::Audit::/,
+  # The beyondcorp/clientconnectorservices client has been turned down
+  /^::Google::Cloud::BeyondCorp::ClientConnectorServices::/,
+  # The GAPIC name for cloudbuild is google-cloud-build-v1
   /^::Google::Cloud::CloudBuild::/,
+  # The IOT client has been turned down
+  /^::Google::Cloud::Iot::/,
+  # Ruby (currently) has no GAPIC for storage
   /^::Google::Cloud::Storage::/,
+  # There is no GAPIC for firebase
   /^::Google::Firebase::/,
 ]
 
@@ -57,6 +88,13 @@ def run
   exit 1 unless issues.empty?
 end
 
+##
+# Evaluate the current git environment to see what files have changed. If this
+# is a pull request, and we have an associated github pull request event, then
+# the pull request diff is used. Otherwise, we look for local diffs from HEAD.
+#
+# @return [Array<String>] An array of file paths
+#
 def find_files
   return Dir.glob "**/*_pb.rb" if all_files
   logger.info "Evaluating changes..."
@@ -73,6 +111,14 @@ def find_files
   files
 end
 
+##
+# Given an array of file paths, return a list of associated module names
+# (excluding the `Events` module) that we should look for in the client library
+# repository.
+#
+# @param files [Array<String>] An array of changed file paths
+# @return [Array<String>] An array of fully-qualified module names
+#
 def find_modules files
   mods = files.map { |file| module_from file }.compact.sort.uniq
   excluded = mods.find_all { |mod| EXCLUDE_MODULES.any? { |regex| regex.match? mod } }
@@ -84,6 +130,12 @@ def find_modules files
   mods
 end
 
+##
+# Get the base and head refs from github.
+#
+# @return [Array(String|nil, String|nil)] The base and head refs. If this does
+#     not appear to be a recognized GitHub event, both values will be nil.
+#
 def interpret_github_event
   payload = github_payload_json
   base_ref, head_ref =
@@ -106,6 +158,14 @@ def interpret_github_event
   [base_ref, head_ref]
 end
 
+##
+# Get a list of changed files.
+# If a base ref is given, we look for the diffs from that base ref.
+# Otherwise, we look for locally modified files from HEAD.
+#
+# @param base_ref [String|nil] The base ref, or nil for none
+# @return [Array<String>] An array of modified file paths
+#
 def find_changed_files base_ref
   if base_ref.nil?
     logger.info "No base ref. Using local diff."
@@ -117,6 +177,9 @@ def find_changed_files base_ref
   end
 end
 
+##
+# Ensure the current head is set to the given head_ref
+#
 def ensure_checkout head_ref
   logger.info "Checking for head ref: #{head_ref}"
   head_sha = ensure_fetched head_ref
@@ -129,6 +192,9 @@ def ensure_checkout head_ref
   end
 end
 
+##
+# Ensure the given ref has been fetched from the remote
+#
 def ensure_fetched ref
   result = exec(["git", "show", "--no-patch", "--format=%H", ref], out: :capture, err: :capture)
   if result.success?
@@ -145,16 +211,36 @@ def ensure_fetched ref
   end
 end
 
+##
+# Given a file, return a fully-qualified module name for the events defined in
+# the module, omitting the `Events` component of the namespace. The returned
+# module name should then be present in an associated client library.
+#
+# @param file [String] File path
+# @return [String] Fully-qualified module name
+#
 def module_from file
   content = File.read file
   match = /\nmodule Google\n  module Events\n(\s+module \w+\n)+/.match content
   return unless match
   parts = match[0].scan(/\n\s*module (\w+)/).flatten
+  # Remove the "Events" module from the namespace, to make it match a module
+  # expected from a client library
   parts.slice! 1
   mod = "::#{parts.join("::")}::"
   mod
 end
 
+##
+# Given a list of module names and a directory, search the directory for GAPIC
+# service pb files, and verify that all modules are accounted for in those
+# files. Return a list of problems encountered (empty if there are no problems).
+#
+# @param modules [Array<String>] List of fully-qualified module names
+# @param dir [String] Path to the google-cloud-ruby repository
+# @return [Array<String>] List of descriptions of problems found, or empty if
+#     no problems found
+#
 def check_modules modules, dir
   contents = Dir.chdir dir do
     Dir.glob("**/*_services_pb.rb").map { |file| File.read file }
@@ -169,6 +255,11 @@ def check_modules modules, dir
   issues
 end
 
+##
+# Print out results
+#
+# @param issues [Array<String>] Issue list
+#
 def output issues
   if issues.empty?
     puts "No naming issues", :green, :bold
@@ -178,6 +269,11 @@ def output issues
   end
 end
 
+##
+# Memoized github event payload
+#
+# @return [Object] Deserialized event payload
+#
 def github_payload_json
   unless defined? @github_payload_json
     @github_payload_json = JSON.load File.read github_event_payload rescue nil

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains types for CloudEvents issued by Google.
 
 ## Prerequisites
 
-- Ruby 3.0 (or higher)
+- Ruby 3.1 (or higher)
 
 ## Installation
 


### PR DESCRIPTION
This PR adds two entries to the exclusion list, corresponding to client libraries that have been turned down. It also expands the documentation for the check-names tool. This should solve the failures in #83.