### PR TITLE
chore: replace old ruby teams with cloud-sdk-ruby-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*     @googleapis/cloudevents-admins @googleapis/ruby-team
+*     @googleapis/cloudevents-admins @googleapis/cloud-sdk-ruby-team


### PR DESCRIPTION
Bug ID: b/479546763