### PR TITLE
chore: replace old partner teams with new ones (Wave 2)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*     @googleapis/cloudevents-admins @googleapis/cloud-sdk-ruby-team
+*     @googleapis/acep-team @googleapis/cloud-sdk-ruby-team


### PR DESCRIPTION
Replacing old partner teams with new ones as part of Wave 2 migration. b/478003109